### PR TITLE
fix(windows): status on directories where not rendered correctly

### DIFF
--- a/lua/oil-git-signs/init.lua
+++ b/lua/oil-git-signs/init.lua
@@ -89,7 +89,7 @@ local function parse_git_status(raw_status)
 
     -- extract the first part of the path (up to first sep)
     local entry = assert( ---@type string
-        path:match(("^([^%s]+)"):format(require("oil.fs").sep)),
+        path:match(("^([^%s]+)"):format("/")),
         "failed to extract entry path"
     )
 


### PR DESCRIPTION
path separator for git status command (/) is not the same as oil.nvim path sep (\\) on windows. I tested every possible shell on and different versions of git on windows on two different machines.

```shell
╭─sb@carter C:\_workspace\Projects\priv\oil-git-signs.nvim ❮main●❯
╰─$ git -c status.relativePaths=true status --short .
 M lua/oil-git-signs/init.lua
```